### PR TITLE
fix: CNAME resolution when External DNS strips trailing dots

### DIFF
--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -44,3 +44,25 @@ func parseArrayFromEnv(env string) []string {
 	}
 	return parts
 }
+
+func adjustCNAMETarget(zones []*hcloud.Zone, dnsName string, target string) (string, error) {
+	zone, err := findZoneByHostname(zones, dnsName)
+	if err != nil {
+		return "", err
+	}
+
+	var adjustedTarget string
+	zoneSuffix := fmt.Sprintf(".%s", zone.Name)
+	absoluteZoneSuffix := fmt.Sprintf(".%s.", zone.Name)
+	switch {
+	case strings.HasSuffix(target, zoneSuffix):
+		adjustedTarget = strings.TrimSuffix(target, zoneSuffix)
+	case strings.HasSuffix(target, absoluteZoneSuffix):
+		adjustedTarget = strings.TrimSuffix(target, absoluteZoneSuffix)
+	default:
+		// ensure CNAME targets in different zones end in a dot
+		adjustedTarget = strings.TrimSuffix(target, ".") + "."
+	}
+
+	return adjustedTarget, nil
+}

--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/net/publicsuffix"
+
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
@@ -45,24 +47,24 @@ func parseArrayFromEnv(env string) []string {
 	return parts
 }
 
-func adjustCNAMETarget(zones []*hcloud.Zone, dnsName string, target string) (string, error) {
-	zone, err := findZoneByHostname(zones, dnsName)
-	if err != nil {
-		return "", err
+// adjustCNAMETarget updates the CNAME record value, to work around the removal of trailing dots in external-dns
+// (https://github.com/kubernetes-sigs/external-dns/issues/6145).
+//
+// Using a relative CNAME target which ends with a public suffix (https://publicsuffix.org/) is not supported,
+// instead users must use an absolute CNAME target.
+//
+// For example given the zone "example.com", the relative target "embedded.other.de" (without trailing dot) must
+// use the following absolute CNAME target "embedded.other.de.example.com."
+//
+//	external-dns.kubernetes.io/hostname: "www.example.com"
+//	external-dns.kubernetes.io/target: "embedded.other.de.example.com."
+func adjustCNAMETarget(target string) string {
+	suffix, icann := publicsuffix.PublicSuffix(target)
+	// If target is ICANN or privately managed, append a trailing dot
+	// https://pkg.go.dev/golang.org/x/net/publicsuffix#example-PublicSuffix-Manager
+	if icann || strings.IndexByte(suffix, '.') >= 0 {
+		return strings.TrimSuffix(target, ".") + "."
 	}
 
-	var adjustedTarget string
-	zoneSuffix := fmt.Sprintf(".%s", zone.Name)
-	absoluteZoneSuffix := fmt.Sprintf(".%s.", zone.Name)
-	switch {
-	case strings.HasSuffix(target, zoneSuffix):
-		adjustedTarget = strings.TrimSuffix(target, zoneSuffix)
-	case strings.HasSuffix(target, absoluteZoneSuffix):
-		adjustedTarget = strings.TrimSuffix(target, absoluteZoneSuffix)
-	default:
-		// ensure CNAME targets in different zones end in a dot
-		adjustedTarget = strings.TrimSuffix(target, ".") + "."
-	}
-
-	return adjustedTarget, nil
+	return target
 }

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
@@ -206,6 +207,52 @@ func TestParseArrayFromEnv(t *testing.T) {
 			envKey := "TEST_DOMAINS"
 			t.Setenv(envKey, tt.env)
 			assert.Equalf(t, tt.want, parseArrayFromEnv(envKey), "parseArrayFromEnv(%v)", tt.env)
+		})
+	}
+}
+
+func TestAdjustCNAMETarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		zones      []*hcloud.Zone
+		dnsName    string
+		target     string
+		rrsetValue string
+	}{
+		{
+			name: "same zone target",
+			zones: []*hcloud.Zone{
+				{Name: "example.de"},
+			},
+			dnsName:    "foo.example.de",
+			target:     "bar.example.de",
+			rrsetValue: "bar",
+		},
+		{
+			name: "same zone absolute target",
+			zones: []*hcloud.Zone{
+				{Name: "example.de"},
+			},
+			dnsName:    "foo.example.de",
+			target:     "bar.example.de.",
+			rrsetValue: "bar",
+		},
+		{
+			name: "different zone target",
+			zones: []*hcloud.Zone{
+				{Name: "example.de"},
+			},
+			dnsName:    "foo.example.de",
+			target:     "foo.example.com.",
+			rrsetValue: "foo.example.com.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, err := adjustCNAMETarget(tt.zones, tt.dnsName, tt.target)
+			require.NoError(t, err)
+			require.Equal(t, tt.rrsetValue, target)
 		})
 	}
 }

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -213,11 +213,12 @@ func TestParseArrayFromEnv(t *testing.T) {
 
 func TestAdjustCNAMETarget(t *testing.T) {
 	tests := []struct {
-		name       string
-		zones      []*hcloud.Zone
-		dnsName    string
-		target     string
-		rrsetValue string
+		name          string
+		zones         []*hcloud.Zone
+		dnsName       string
+		target        string
+		rrsetValue    string
+		expectedError error
 	}{
 		{
 			name: "same zone target",
@@ -246,12 +247,21 @@ func TestAdjustCNAMETarget(t *testing.T) {
 			target:     "foo.example.com.",
 			rrsetValue: "foo.example.com.",
 		},
+		{
+			name: "unknown zone",
+			zones: []*hcloud.Zone{
+				{Name: "example.de"},
+			},
+			dnsName:       "foo.example.com",
+			target:        "foo.example.com.",
+			expectedError: fmt.Errorf("could not find zone with hostname: %s", "foo.example.com"),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			target, err := adjustCNAMETarget(tt.zones, tt.dnsName, tt.target)
-			require.NoError(t, err)
+			require.Equal(t, tt.expectedError, err)
 			require.Equal(t, tt.rrsetValue, target)
 		})
 	}

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -213,56 +213,56 @@ func TestParseArrayFromEnv(t *testing.T) {
 
 func TestAdjustCNAMETarget(t *testing.T) {
 	tests := []struct {
-		name          string
-		zones         []*hcloud.Zone
-		dnsName       string
-		target        string
-		rrsetValue    string
-		expectedError error
+		name       string
+		zone       *hcloud.Zone
+		dnsName    string
+		target     string
+		wantTarget string
 	}{
 		{
-			name: "same zone target",
-			zones: []*hcloud.Zone{
-				{Name: "example.de"},
-			},
-			dnsName:    "foo.example.de",
-			target:     "bar.example.de",
-			rrsetValue: "bar",
+			name:       "absolute target in same zone",
+			zone:       &hcloud.Zone{Name: "example.de"},
+			dnsName:    "www.example.de",
+			target:     "node1.example.de",
+			wantTarget: "node1.example.de.",
 		},
 		{
-			name: "same zone absolute target",
-			zones: []*hcloud.Zone{
-				{Name: "example.de"},
-			},
-			dnsName:    "foo.example.de",
-			target:     "bar.example.de.",
-			rrsetValue: "bar",
+			name:       "absolute target in other zone",
+			zone:       &hcloud.Zone{Name: "example.de"},
+			dnsName:    "www.example.de",
+			target:     "node1.other.de",
+			wantTarget: "node1.other.de.",
 		},
 		{
-			name: "different zone target",
-			zones: []*hcloud.Zone{
-				{Name: "example.de"},
-			},
-			dnsName:    "foo.example.de",
-			target:     "foo.example.com.",
-			rrsetValue: "foo.example.com.",
+			name:       "relative target in same zone",
+			zone:       &hcloud.Zone{Name: "example.de"},
+			dnsName:    "www.example.de",
+			target:     "node1",
+			wantTarget: "node1",
 		},
 		{
-			name: "unknown zone",
-			zones: []*hcloud.Zone{
-				{Name: "example.de"},
-			},
-			dnsName:       "foo.example.com",
-			target:        "foo.example.com.",
-			expectedError: fmt.Errorf("could not find zone with hostname: %s", "foo.example.com"),
+			// external-dns always strips the trailing dots, but we want to make sure we
+			// handle this case if it were to change.
+			name:       "absolute target in same zone with trailing dot",
+			zone:       &hcloud.Zone{Name: "example.de"},
+			dnsName:    "www.example.de",
+			target:     "node1.example.de.",
+			wantTarget: "node1.example.de.",
+		},
+		{
+			// external-dns always strips the trailing dots, but we want to make sure we
+			// handle this case if it were to change.
+			name:       "absolute target in other zone with trailing dot",
+			zone:       &hcloud.Zone{Name: "example.de"},
+			dnsName:    "www.example.de",
+			target:     "node1.other.de.",
+			wantTarget: "node1.other.de.",
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			target, err := adjustCNAMETarget(tt.zones, tt.dnsName, tt.target)
-			require.Equal(t, tt.expectedError, err)
-			require.Equal(t, tt.rrsetValue, target)
+			target := adjustCNAMETarget(tt.target)
+			require.Equal(t, tt.wantTarget, target)
 		})
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -145,6 +145,13 @@ func (p *Provider) applyCreateChanges(
 
 		var records []hcloud.ZoneRRSetRecord
 		for _, target := range ep.Targets {
+			if ep.RecordType == "CNAME" {
+				target, err = adjustCNAMETarget(zones, ep.DNSName, target)
+				if err != nil {
+					return err
+				}
+			}
+
 			records = append(records, hcloud.ZoneRRSetRecord{Value: target})
 		}
 
@@ -279,6 +286,13 @@ func (p *Provider) applyUpdateChanges(
 
 			records := make([]hcloud.ZoneRRSetRecord, 0, len(endpointsNew[i].Targets))
 			for _, target := range endpointsNew[i].Targets {
+				if endpointsNew[i].RecordType == "CNAME" {
+					target, err = adjustCNAMETarget(zones, endpointsNew[i].DNSName, target)
+					if err != nil {
+						return err
+					}
+				}
+
 				records = append(records, hcloud.ZoneRRSetRecord{Value: target})
 			}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -41,13 +41,29 @@ func (p *Provider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.
 		if err != nil {
 			return nil, err
 		}
+		if ep.DNSName != dnsName {
+			p.logger.Debug(
+				"adjusted endpoint dns name",
+				"old-dns-name", ep.DNSName,
+				"new-dns-name", dnsName,
+			)
+			ep.DNSName = dnsName
+		}
 
-		p.logger.Debug(
-			"adjusted endpoint",
-			"input", ep.DNSName,
-			"output", dnsName,
-		)
-		ep.DNSName = dnsName
+		if ep.RecordType == "CNAME" {
+			for i := range ep.Targets {
+				target := adjustCNAMETarget(ep.Targets[i])
+				if ep.Targets[i] != target {
+					p.logger.Debug(
+						"adjusted endpoint target",
+						"dns-name", ep.DNSName,
+						"old-target", ep.Targets[i],
+						"new-target", target,
+					)
+					ep.Targets[i] = target
+				}
+			}
+		}
 	}
 	return endpoints, nil
 }
@@ -145,13 +161,6 @@ func (p *Provider) applyCreateChanges(
 
 		var records []hcloud.ZoneRRSetRecord
 		for _, target := range ep.Targets {
-			if ep.RecordType == "CNAME" {
-				target, err = adjustCNAMETarget(zones, ep.DNSName, target)
-				if err != nil {
-					return err
-				}
-			}
-
 			records = append(records, hcloud.ZoneRRSetRecord{Value: target})
 		}
 
@@ -286,13 +295,6 @@ func (p *Provider) applyUpdateChanges(
 
 			records := make([]hcloud.ZoneRRSetRecord, 0, len(endpointsNew[i].Targets))
 			for _, target := range endpointsNew[i].Targets {
-				if endpointsNew[i].RecordType == "CNAME" {
-					target, err = adjustCNAMETarget(zones, endpointsNew[i].DNSName, target)
-					if err != nil {
-						return err
-					}
-				}
-
 				records = append(records, hcloud.ZoneRRSetRecord{Value: target})
 			}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -253,6 +253,46 @@ func TestApplyCreateChanges(t *testing.T) {
 				return mocks
 			},
 		},
+		{
+			name:       "create a single cname rrset",
+			zoneNameFn: func(id string) string { return fmt.Sprintf("example-%s.com", id) },
+			inputEndpointsFn: func(zoneName string) []*endpoint.Endpoint {
+				return []*endpoint.Endpoint{
+					{
+						DNSName:    fmt.Sprintf("%s.%s", "test", zoneName),
+						RecordType: "CNAME",
+						Targets:    []string{"foo.mydomain.com"},
+					},
+				}
+			},
+			mocksFn: func(zoneName string, inputEndpoints []*endpoint.Endpoint) []mockutil.Request {
+				mocks := make([]mockutil.Request, 0, len(inputEndpoints))
+				for _, ep := range inputEndpoints {
+					mocks = append(mocks, mockutil.Request{
+						Method: "POST",
+						Path:   fmt.Sprintf("/zones/%s/rrsets/%s/%s/actions/add_records", zoneName, "test", ep.RecordType),
+						Status: 200,
+						Want: func(t *testing.T, r *http.Request) {
+							request := schema.ZoneRRSetAddRecordsRequest{}
+							require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+							assert.Equal(
+								t,
+								schema.ZoneRRSetAddRecordsRequest{
+									Records: []schema.ZoneRRSetRecord{
+										{Value: "foo.mydomain.com."},
+									},
+								},
+								request,
+							)
+						},
+						JSON: schema.ActionGetResponse{
+							Action: schema.Action{ID: 1, Command: "add_rrset_records", Status: "success"},
+						},
+					})
+				}
+				return mocks
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -448,8 +488,8 @@ func TestApplyUpdateChanges(t *testing.T) {
 				return []*endpoint.Endpoint{
 					{
 						DNSName:    fmt.Sprintf("%s.%s", "test", zoneName),
-						RecordType: "A",
-						Targets:    []string{"127.0.0.1"},
+						RecordType: "CNAME",
+						Targets:    []string{"foo.mydomain.com"},
 					},
 				}
 			},
@@ -457,8 +497,8 @@ func TestApplyUpdateChanges(t *testing.T) {
 				return []*endpoint.Endpoint{
 					{
 						DNSName:    fmt.Sprintf("%s.%s", "test", zoneName),
-						RecordType: "A",
-						Targets:    []string{"192.168.0.1"},
+						RecordType: "CNAME",
+						Targets:    []string{"bar.mydomain.com"},
 					},
 				}
 			},
@@ -475,7 +515,7 @@ func TestApplyUpdateChanges(t *testing.T) {
 							assert.Equal(
 								t,
 								schema.ZoneRRSetSetRecordsRequest{
-									Records: []schema.ZoneRRSetRecord{{Value: "192.168.0.1"}},
+									Records: []schema.ZoneRRSetRecord{{Value: "bar.mydomain.com."}},
 								},
 								request,
 							)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -26,40 +26,46 @@ func TestAdjustEndpoints(t *testing.T) {
 		{
 			name: "convert to lowercase",
 			incoming: []*endpoint.Endpoint{
-				{
-					DNSName: "MyDomain.example.com",
-				},
+				{DNSName: "MyDomain.example.com"},
 			},
 			expected: []*endpoint.Endpoint{
-				{
-					DNSName: "mydomain.example.com",
-				},
+				{DNSName: "mydomain.example.com"},
 			},
 		},
 		{
 			name: "convert to punicode",
 			incoming: []*endpoint.Endpoint{
-				{
-					DNSName: "mydømain.example.com",
-				},
+				{DNSName: "mydømain.example.com"},
 			},
 			expected: []*endpoint.Endpoint{
-				{
-					DNSName: "xn--mydmain-s1a.example.com",
-				},
+				{DNSName: "xn--mydmain-s1a.example.com"},
 			},
 		},
 		{
 			name: "trim trailing dot",
 			incoming: []*endpoint.Endpoint{
-				{
-					DNSName: "mydomain.example.com.",
-				},
+				{DNSName: "mydomain.example.com."},
 			},
 			expected: []*endpoint.Endpoint{
-				{
-					DNSName: "mydomain.example.com",
-				},
+				{DNSName: "mydomain.example.com"},
+			},
+		},
+		{
+			name: "CNAME targets",
+			incoming: []*endpoint.Endpoint{
+				{DNSName: "example.com.", RecordType: "CNAME", Targets: []string{"mydomain.example.com"}},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "example.com", RecordType: "CNAME", Targets: []string{"mydomain.example.com."}},
+			},
+		},
+		{
+			name: "MX targets",
+			incoming: []*endpoint.Endpoint{
+				{DNSName: "example.com.", RecordType: "MX", Targets: []string{"mydomain.example.com"}},
+			},
+			expected: []*endpoint.Endpoint{
+				{DNSName: "example.com", RecordType: "MX", Targets: []string{"mydomain.example.com"}},
 			},
 		},
 	}
@@ -75,7 +81,7 @@ func TestAdjustEndpoints(t *testing.T) {
 			assert.Len(t, actual, len(tt.expected))
 
 			for i, ep := range actual {
-				assert.Equal(t, tt.expected[i].DNSName, ep.DNSName)
+				assert.Equal(t, tt.expected[i], ep)
 			}
 		})
 	}
@@ -261,7 +267,7 @@ func TestApplyCreateChanges(t *testing.T) {
 					{
 						DNSName:    fmt.Sprintf("%s.%s", "test", zoneName),
 						RecordType: "CNAME",
-						Targets:    []string{"foo.mydomain.com"},
+						Targets:    []string{"foo.mydomain.com."},
 					},
 				}
 			},
@@ -498,7 +504,7 @@ func TestApplyUpdateChanges(t *testing.T) {
 					{
 						DNSName:    fmt.Sprintf("%s.%s", "test", zoneName),
 						RecordType: "CNAME",
-						Targets:    []string{"bar.mydomain.com"},
+						Targets:    []string{"bar.mydomain.com."},
 					},
 				}
 			},
@@ -542,7 +548,6 @@ func TestApplyUpdateChanges(t *testing.T) {
 			hetznerProvider := NewProvider(client, logger)
 
 			zones := []*hcloud.Zone{{Name: zoneName}}
-
 			err := hetznerProvider.applyUpdateChanges(ctx, zones, oldEndpoints, newEndpoints)
 			assert.NoError(t, err)
 		})

--- a/tests/e2e/cluster.go
+++ b/tests/e2e/cluster.go
@@ -188,6 +188,7 @@ func (c *Cluster) Cleanup() error {
 func (c *Cluster) WaitForRRSetCondition(
 	ctx context.Context,
 	subdomain string,
+	rrSetType hcloud.ZoneRRSetType,
 	condition func(zoneRRSet *hcloud.ZoneRRSet) bool,
 ) (*hcloud.ZoneRRSet, error) {
 	backoffFn := hcloud.ExponentialBackoffWithOpts(
@@ -204,7 +205,7 @@ func (c *Cluster) WaitForRRSetCondition(
 			ctx,
 			c.zone,
 			subdomain,
-			hcloud.ZoneRRSetTypeA,
+			rrSetType,
 		)
 		if err != nil {
 			if !hcloud.IsError(err, hcloud.ErrorCodeNotFound) {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -113,6 +113,7 @@ func TestCreateRecords(t *testing.T) {
 			zoneRRSet, err := cluster.WaitForRRSetCondition(
 				ctx,
 				recordNamePunycode,
+				hcloud.ZoneRRSetTypeA,
 				func(zoneRRSet *hcloud.ZoneRRSet) bool {
 					return zoneRRSet != nil
 				},
@@ -121,6 +122,72 @@ func TestCreateRecords(t *testing.T) {
 			require.NotNil(t, zoneRRSet)
 
 			tt.expect(t, svc, zoneRRSet)
+		})
+	}
+}
+
+func TestCreateCNAMERecords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{
+			name:   "absolute target in the same zone",
+			target: fmt.Sprintf("nginx.%s", cluster.zone.Name),
+			want:   fmt.Sprintf("nginx.%s.", cluster.zone.Name),
+		},
+		{
+			name:   "absolute target in the same zone (trailing dot stripped by external-dns)",
+			target: fmt.Sprintf("nginx.%s.", cluster.zone.Name),
+			want:   fmt.Sprintf("nginx.%s.", cluster.zone.Name),
+		},
+		{
+			name:   "absolute target in other zone",
+			target: "nginx.other.com",
+			want:   "nginx.other.com.",
+		},
+		{
+			name:   "absolute target in other zone (trailing dot stripped by external-dns)",
+			target: "nginx.other.com.",
+			want:   "nginx.other.com.",
+		},
+		{
+			name:   "relative target in the same zone",
+			target: "nginx",
+			want:   "nginx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			recordName := fmt.Sprintf("nginx-%s", randutil.GenerateID())
+
+			fqdn, err := cluster.GenerateFQDN(recordName)
+			require.NoError(t, err)
+
+			_, err = cluster.ApplyService(ctx, recordName, map[string]string{
+				"hostname": fqdn,
+				"target":   tt.target,
+			})
+			require.NoError(t, err)
+
+			zoneRRSet, err := cluster.WaitForRRSetCondition(
+				ctx,
+				recordName,
+				hcloud.ZoneRRSetTypeCNAME,
+				func(zoneRRSet *hcloud.ZoneRRSet) bool {
+					return zoneRRSet != nil
+				},
+			)
+			require.NoError(t, err)
+			require.NotNil(t, zoneRRSet)
+
+			require.Len(t, zoneRRSet.Records, 1)
+			assert.Equal(t, tt.want, zoneRRSet.Records[0].Value)
 		})
 	}
 }
@@ -146,6 +213,7 @@ func TestSimpleRecordLifecycle(t *testing.T) {
 		zoneRRSet, err := cluster.WaitForRRSetCondition(
 			ctx,
 			recordName,
+			hcloud.ZoneRRSetTypeA,
 			func(zoneRRSet *hcloud.ZoneRRSet) bool {
 				return zoneRRSet != nil
 			},
@@ -161,6 +229,7 @@ func TestSimpleRecordLifecycle(t *testing.T) {
 		zoneRRSet, err := cluster.WaitForRRSetCondition(
 			ctx,
 			recordName,
+			hcloud.ZoneRRSetTypeA,
 			func(zoneRRSet *hcloud.ZoneRRSet) bool {
 				return zoneRRSet == nil
 			},
@@ -192,6 +261,7 @@ func TestUpdateRecordTTL(t *testing.T) {
 		zoneRRSet, err := cluster.WaitForRRSetCondition(
 			ctx,
 			recordName,
+			hcloud.ZoneRRSetTypeA,
 			func(zoneRRSet *hcloud.ZoneRRSet) bool {
 				return zoneRRSet != nil
 			},
@@ -215,6 +285,7 @@ func TestUpdateRecordTTL(t *testing.T) {
 		zoneRRSet, err := cluster.WaitForRRSetCondition(
 			ctx,
 			recordName,
+			hcloud.ZoneRRSetTypeA,
 			func(zoneRRSet *hcloud.ZoneRRSet) bool {
 				return zoneRRSet != nil && *zoneRRSet.TTL != 1800
 			},


### PR DESCRIPTION
External DNS normalizes CNAME targets by removing the trailing dot, which causes CNAME records pointing to a different domain to resolve incorrectly (e.g. `foo.mytarget.com.myzone.com`).

External DNS is normalizing CNAMES in multiple locations of their code:
- https://github.com/kubernetes-sigs/external-dns/blob/910dc785d86fbe97c32dabbf4eb0c1d27b84bb4e/source/annotations/processors.go#L103-L118
- https://github.com/kubernetes-sigs/external-dns/blob/910dc785d86fbe97c32dabbf4eb0c1d27b84bb4e/endpoint/endpoint.go#L270

For this reason, other providers implement a check to ensure the trailing dot is present according to the needs of their DNS system:
- Google: https://github.com/kubernetes-sigs/external-dns/blob/910dc785d86fbe97c32dabbf4eb0c1d27b84bb4e/provider/google/google.go#L427-L429
- DigitalOcean: https://github.com/kubernetes-sigs/external-dns/blob/910dc785d86fbe97c32dabbf4eb0c1d27b84bb4e/provider/digitalocean/digital_ocean.go#L292-L294
- OVH: https://github.com/kubernetes-sigs/external-dns/blob/910dc785d86fbe97c32dabbf4eb0c1d27b84bb4e/provider/ovh/ovh.go#L735-L749

The exact reasoning for this normalization is not documented by External DNS.

`adjustCNAMETarget` (`internal/provider/helper.go`) restores the trailing dot by deciding
whether a target is a FQDN, using the Public Suffix List
([publicsuffix.org](https://publicsuffix.org/)) via `golang.org/x/net/publicsuffix`. If the
target ends in a public suffix it is made absolute; otherwise it is left untouched
and stays a relative name within the zone.

This runs in `AdjustEndpoints`, so it applies once to every CNAME endpoint before any
create or update is built, and only to `CNAME`.

| Target from external-dns | Stored value |
| --- | --- |
| `nginx.example.com` | `nginx.example.com.` |
| `nginx.other.com` | `nginx.other.com.` |
| `nginx` (relative) | `nginx` |

#### Known limitation

A relative target that happens to end in a public suffix cannot be expressed as such,
because it is indistinguishable from a FQDN. Users must write the absolute form instead
for zone `example.com`, the relative target `embedded.other.de` has to be given as:

```yaml
external-dns.kubernetes.io/hostname: "www.example.com"
external-dns.kubernetes.io/target: "embedded.other.de.example.com."
```

Fixes #73