### PR TITLE
fix: ensure longest matching zone is selected

### DIFF
--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -9,13 +9,19 @@ import (
 )
 
 func findZoneByHostname(zones []*hcloud.Zone, hostname string) (*hcloud.Zone, error) {
+	var match *hcloud.Zone
 	for _, zone := range zones {
 		if strings.HasSuffix(hostname, zone.Name) {
-			return zone, nil
+			// Ensures the longest match is returned
+			if match == nil || len(match.Name) < len(zone.Name) {
+				match = zone
+			}
 		}
 	}
-
-	return nil, fmt.Errorf("could not find zone with hostname: %s", hostname)
+	if match == nil {
+		return nil, fmt.Errorf("could not find zone with hostname: %s", hostname)
+	}
+	return match, nil
 }
 
 func getZoneRRSetName(dnsName string, zone *hcloud.Zone) string {

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -57,6 +57,38 @@ func TestFindZoneByHostname(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "no shorter suffix match",
+			zones: []*hcloud.Zone{
+				{
+					Name: "example.org",
+				},
+				{
+					Name: "prefix-example.org",
+				},
+			},
+			hostname: "testing.prefix-example.org",
+			want: &hcloud.Zone{
+				Name: "prefix-example.org",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "no longer suffix match",
+			zones: []*hcloud.Zone{
+				{
+					Name: "example.org",
+				},
+				{
+					Name: "prefix-example.org",
+				},
+			},
+			hostname: "testing.example.org",
+			want: &hcloud.Zone{
+				Name: "example.org",
+			},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "no zone found",
 			zones: []*hcloud.Zone{
 				{


### PR DESCRIPTION
Closes https://github.com/hetzner/external-dns-hetzner-webhook/issues/111

Given:
- example.com
- longernameexample.com

Records requested for longernameexample.com will be incorrectly routed to example.com because longernameexample.com ends with example.com.