### PR TITLE
test: increase external-dns webhook timeout

### DIFF
--- a/tests/e2e/cluster.go
+++ b/tests/e2e/cluster.go
@@ -234,6 +234,8 @@ func (c *Cluster) StartExternalDNS(ctx context.Context) (*exec.Cmd, error) {
 		ctx,
 		"../../external-dns",
 		"--provider", "webhook",
+		"--webhook-provider-read-timeout", "60s",
+		"--webhook-provider-write-timeout", "60s",
 		"--source", "service",
 		"--events",
 		"--interval", "60m",

--- a/tests/e2e/cluster.go
+++ b/tests/e2e/cluster.go
@@ -237,7 +237,7 @@ func (c *Cluster) StartExternalDNS(ctx context.Context) (*exec.Cmd, error) {
 		// Longer running actions might cause the tests to be flaky.
 		// Increase the default timeouts for our test suite.
 		"--webhook-provider-read-timeout", "60s",
-		"--webhook-provider-write-timeout", "60s",
+		"--webhook-provider-write-timeout", "15s",
 		"--source", "service",
 		"--events",
 		"--interval", "60m",

--- a/tests/e2e/cluster.go
+++ b/tests/e2e/cluster.go
@@ -234,6 +234,8 @@ func (c *Cluster) StartExternalDNS(ctx context.Context) (*exec.Cmd, error) {
 		ctx,
 		"../../external-dns",
 		"--provider", "webhook",
+		// Longer running actions might cause the tests to be flaky.
+		// Increase the default timeouts for our test suite.
 		"--webhook-provider-read-timeout", "60s",
 		"--webhook-provider-write-timeout", "60s",
 		"--source", "service",


### PR DESCRIPTION
As we wait for the Hetzner Cloud Actions in our endpoints, this
might cause flaky tests when running into the default timeouts.
