### PR TITLE
test: kubernetes v1.35

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
           - 1.32
           - 1.33
           - 1.34
+          - 1.35
 
     env:
       KUBERNETES_VERSION: ${{ matrix.k8s }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false # Continue tests matrix if a flaky run occurs.
       matrix:
         k8s:
-          - 1.32
           - 1.33
           - 1.34
           - 1.35


### PR DESCRIPTION
We have already pulled in all the dependencies and external-dns
also bumped their deps to k8s v1.35 in v0.21.0. We can add v1.35
to the tests.
