### PR TITLE
chore: add renovate regex manager for external-dns helm chart version

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -18,7 +18,7 @@ deploy:
         namespace: default
         remoteChart: external-dns
         repo: https://kubernetes-sigs.github.io/external-dns/
-        version: 1.15.0
+        version: 1.15.0 # renovate: datasource=github-releases depName=kubernetes-sigs/external-dns extractVersion=external-dns-helm-chart-(?<version>.*)
         setValueTemplates:
           provider:
             webhook:
@@ -39,3 +39,5 @@ deploy:
                     secretKeyRef:
                       name: hetzner
                       key: token
+                - name: LOG_LEVEL
+                  value: debug


### PR DESCRIPTION
- Add renovate regex manager to update the external dns helm chart version
- Always use debug log level when running with skaffold