### PR TITLE
refactor: feature gate relative cname targets

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -4,4 +4,5 @@ In this folder, you should find guides for you to accomplish specific tasks with
 
 - [Quickstart](quickstart.md)
 - [Monitoring](monitoring.md)
+- [Allow relative CNAME targets](allow-relative-cname-targets.md)
 - [Troubleshooting](troubleshooting.md)

--- a/docs/guides/allow-relative-cname-targets.md
+++ b/docs/guides/allow-relative-cname-targets.md
@@ -9,12 +9,12 @@ ExternalDNS strips the trailing dot from CNAME targets
 pointing to another domain resolve within the zone of the record. The webhook therefore restores the trailing
 dot and stores every CNAME target as an absolute name:
 
-| Target from ExternalDNS | Stored value         |
-| ----------------------- | -------------------- |
-| `nginx.example.com`     | `nginx.example.com.` |
-| `nginx.absolute.com.`     | `nginx.absolute.com.` |
-| `nginx.other.com`       | `nginx.other.com.`   |
-| `nginx`                 | `nginx.`             |
+| Target from ExternalDNS | Stored value          |
+| ----------------------- | --------------------- |
+| `nginx.example.com`     | `nginx.example.com.`  |
+| `nginx.absolute.com.`   | `nginx.absolute.com.` |
+| `nginx.other.com`       | `nginx.other.com.`    |
+| `nginx`                 | `nginx.`              |
 
 This means relative CNAME targets cannot be used, a target such as `nginx` is stored as the absolute name
 `nginx.` instead of being resolved within the zone of the record.
@@ -44,19 +44,22 @@ provider:
 Targets will then only made absolute if they end with a [public suffix](https://publicsuffix.org/), every other
 targets are left untouched and stays relative to the zone of the record:
 
-| Target from ExternalDNS | Stored value         |
-| ----------------------- | -------------------- |
-| `nginx.example.com`     | `nginx.example.com.` |
-| `nginx.absolute.com.`     | `nginx.absolute.com.` |
-| `nginx.other.com`       | `nginx.other.com.`   |
-| `nginx`                 | `nginx`              |
-| `nginx.`     | `nginx` |
+| Target from ExternalDNS | Stored value          |
+| ----------------------- | --------------------- |
+| `nginx.example.com`     | `nginx.example.com.`  |
+| `nginx.absolute.com.`   | `nginx.absolute.com.` |
+| `nginx.other.com`       | `nginx.other.com.`    |
+| `nginx`                 | `nginx`               |
+| `nginx.`                | `nginx`               |
 
 ## Known limitation
 
-With `ALLOW_RELATIVE_CNAME_TARGETS` enabled, a relative target which ends with a public suffix cannot be expressed, because it is indistinguishable from an absolute target. You must use the absolute form instead, for the zone `example.com` the relative target `embedded.other.de` has to be given as:
+With `ALLOW_RELATIVE_CNAME_TARGETS` enabled, a relative target which ends with a public suffix cannot be expressed, because it is indistinguishable from an absolute target. You must use the absolute form instead. For the zone `example.com`, the relative target `embedded.other.de` has to be given as:
 
 ```yaml
 external-dns.kubernetes.io/hostname: "www.example.com"
 external-dns.kubernetes.io/target: "embedded.other.de.example.com."
 ```
+
+> [!NOTE]
+> We recommend always using an absolute target name (fully-qualified, ending with a `.`) to prevent confusion between relative and absolute targets, unless you know what you are doing.

--- a/docs/guides/allow-relative-cname-targets.md
+++ b/docs/guides/allow-relative-cname-targets.md
@@ -1,0 +1,61 @@
+# Allow relative CNAME targets
+
+This page describes how to use relative CNAME targets with the ExternalDNS Hetzner webhook.
+
+## Default behaviour
+
+ExternalDNS strips the trailing dot from CNAME targets
+([external-dns#6145](https://github.com/kubernetes-sigs/external-dns/issues/6145)), which would make a target
+pointing to another domain resolve within the zone of the record. The webhook therefore restores the trailing
+dot and stores every CNAME target as an absolute name:
+
+| Target from ExternalDNS | Stored value         |
+| ----------------------- | -------------------- |
+| `nginx.example.com`     | `nginx.example.com.` |
+| `nginx.other.com`       | `nginx.other.com.`   |
+| `nginx`                 | `nginx.`             |
+
+This means relative CNAME targets cannot be used, a target such as `nginx` is stored as the absolute name
+`nginx.` instead of being resolved within the zone of the record.
+
+## Enable relative CNAME targets
+
+If you rely on relative CNAME targets, set the
+[`ALLOW_RELATIVE_CNAME_TARGETS`](../reference/configuration.md#supported-environment-variables) environment
+variable to `true`:
+
+```yaml
+# values.yml
+# [...]
+provider:
+  # [...]
+  webhook:
+    env:
+      - name: ALLOW_RELATIVE_CNAME_TARGETS
+        value: "true"
+      - name: HETZNER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: hetzner
+            key: token
+```
+
+Targets are then only made absolute if they end with a [public suffix](https://publicsuffix.org/), every other
+target is left untouched and stays relative to the zone of the record:
+
+| Target from ExternalDNS | Stored value         |
+| ----------------------- | -------------------- |
+| `nginx.example.com`     | `nginx.example.com.` |
+| `nginx.other.com`       | `nginx.other.com.`   |
+| `nginx`                 | `nginx`              |
+
+## Known limitation
+
+With `ALLOW_RELATIVE_CNAME_TARGETS` enabled, a relative target which ends with a public suffix cannot be
+expressed, because it is indistinguishable from an absolute target. You must use the absolute form instead, for
+the zone `example.com` the relative target `embedded.other.de` has to be given as:
+
+```yaml
+external-dns.kubernetes.io/hostname: "www.example.com"
+external-dns.kubernetes.io/target: "embedded.other.de.example.com."
+```

--- a/docs/guides/allow-relative-cname-targets.md
+++ b/docs/guides/allow-relative-cname-targets.md
@@ -12,6 +12,7 @@ dot and stores every CNAME target as an absolute name:
 | Target from ExternalDNS | Stored value         |
 | ----------------------- | -------------------- |
 | `nginx.example.com`     | `nginx.example.com.` |
+| `nginx.absolute.com.`     | `nginx.absolute.com.` |
 | `nginx.other.com`       | `nginx.other.com.`   |
 | `nginx`                 | `nginx.`             |
 
@@ -40,20 +41,20 @@ provider:
             key: token
 ```
 
-Targets are then only made absolute if they end with a [public suffix](https://publicsuffix.org/), every other
-target is left untouched and stays relative to the zone of the record:
+Targets will then only made absolute if they end with a [public suffix](https://publicsuffix.org/), every other
+targets are left untouched and stays relative to the zone of the record:
 
 | Target from ExternalDNS | Stored value         |
 | ----------------------- | -------------------- |
 | `nginx.example.com`     | `nginx.example.com.` |
+| `nginx.absolute.com.`     | `nginx.absolute.com.` |
 | `nginx.other.com`       | `nginx.other.com.`   |
 | `nginx`                 | `nginx`              |
+| `nginx.`     | `nginx` |
 
 ## Known limitation
 
-With `ALLOW_RELATIVE_CNAME_TARGETS` enabled, a relative target which ends with a public suffix cannot be
-expressed, because it is indistinguishable from an absolute target. You must use the absolute form instead, for
-the zone `example.com` the relative target `embedded.other.de` has to be given as:
+With `ALLOW_RELATIVE_CNAME_TARGETS` enabled, a relative target which ends with a public suffix cannot be expressed, because it is indistinguishable from an absolute target. You must use the absolute form instead, for the zone `example.com` the relative target `embedded.other.de` has to be given as:
 
 ```yaml
 external-dns.kubernetes.io/hostname: "www.example.com"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -4,16 +4,17 @@ This page references the different configurations for the External DNS Hetzner w
 
 ## Supported environment variables
 
-| Env                            | Type                  | Default          | Description                                                                                                          |
-| ------------------------------ | --------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `HETZNER_TOKEN`                | string (**required**) |                  | Hetzner Cloud API token.                                                                                             |
-| `INCLUDE_DOMAIN_FILTER`        | list of string        |                  | Inclusive filtering of target zones via domain suffixes. See [domain filters](#domain-filters) for more details.     |
-| `EXCLUDE_DOMAIN_FILTER`        | list of string        |                  | Exclusive filtering of target zones via domain suffixes. See [domain filters](#domain-filters) for more details.     |
-| `INCLUDE_REGEXP_DOMAIN_FILTER` | string                |                  | Inclusive filtering of target zones via regular expressions. See [domain filters](#domain-filters) for more details. |
-| `EXCLUDE_REGEXP_DOMAIN_FILTER` | string                |                  | Exclusive filtering of target zones via regular expressions. See [domain filters](#domain-filters) for more details. |
-| `LOG_LEVEL`                    | string                | `info`           | Log level of the webhook. Accepted values are `debug`, `info`, `warn`, `error`.                                      |
-| `WEBHOOK_ADDRESS`              | string                | `localhost:8888` | Listen address of the webhook.                                                                                       |
-| `METRICS_ADDRESS`              | string                | `:8080`          | Listen address of the prometheus metrics and health checks.                                                          |
+| Env                            | Type                  | Default          | Description                                                                                                                              |
+| ------------------------------ | --------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `HETZNER_TOKEN`                | string (**required**) |                  | Hetzner Cloud API token.                                                                                                                 |
+| `INCLUDE_DOMAIN_FILTER`        | list of string        |                  | Inclusive filtering of target zones via domain suffixes. See [domain filters](#domain-filters) for more details.                         |
+| `EXCLUDE_DOMAIN_FILTER`        | list of string        |                  | Exclusive filtering of target zones via domain suffixes. See [domain filters](#domain-filters) for more details.                         |
+| `INCLUDE_REGEXP_DOMAIN_FILTER` | string                |                  | Inclusive filtering of target zones via regular expressions. See [domain filters](#domain-filters) for more details.                     |
+| `EXCLUDE_REGEXP_DOMAIN_FILTER` | string                |                  | Exclusive filtering of target zones via regular expressions. See [domain filters](#domain-filters) for more details.                     |
+| `ALLOW_RELATIVE_CNAME_TARGETS` | boolean               | `false`          | Keep CNAME targets relative to the zone. See [allow relative CNAME targets](../guides/allow-relative-cname-targets.md) for more details. |
+| `LOG_LEVEL`                    | string                | `info`           | Log level of the webhook. Accepted values are `debug`, `info`, `warn`, `error`.                                                          |
+| `WEBHOOK_ADDRESS`              | string                | `localhost:8888` | Listen address of the webhook.                                                                                                           |
+| `METRICS_ADDRESS`              | string                | `:8080`          | Listen address of the prometheus metrics and health checks.                                                                              |
 
 ### Domain filters
 

--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -50,15 +50,24 @@ func parseArrayFromEnv(env string) []string {
 // adjustCNAMETarget updates the CNAME record value, to work around the removal of trailing dots in external-dns
 // (https://github.com/kubernetes-sigs/external-dns/issues/6145).
 //
-// Using a relative CNAME target which ends with a public suffix (https://publicsuffix.org/) is not supported,
-// instead users must use an absolute CNAME target.
+// By default every target is made absolute by appending a trailing dot, this means relative targets cannot be
+// used.
+//
+// With allowRelativeCNAMETargets enabled, a target is only made absolute if it ends with a public suffix
+// (https://publicsuffix.org/), every other target is left untouched and stays relative to the zone of the
+// record. A relative target which ends with a public suffix is not supported in this mode, because it cannot
+// be told apart from an absolute target, instead users must use an absolute target.
 //
 // For example given the zone "example.com", the relative target "embedded.other.de" (without trailing dot) must
 // use the following absolute CNAME target "embedded.other.de.example.com."
 //
 //	external-dns.kubernetes.io/hostname: "www.example.com"
 //	external-dns.kubernetes.io/target: "embedded.other.de.example.com."
-func adjustCNAMETarget(target string) string {
+func adjustCNAMETarget(target string, allowRelativeCNAMETargets bool) string {
+	if !allowRelativeCNAMETargets {
+		return strings.TrimSuffix(target, ".") + "."
+	}
+
 	suffix, icann := publicsuffix.PublicSuffix(target)
 	// If target is ICANN or privately managed, append a trailing dot
 	// https://pkg.go.dev/golang.org/x/net/publicsuffix#example-PublicSuffix-Manager

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -213,56 +213,73 @@ func TestParseArrayFromEnv(t *testing.T) {
 
 func TestAdjustCNAMETarget(t *testing.T) {
 	tests := []struct {
-		name       string
-		zone       *hcloud.Zone
-		dnsName    string
-		target     string
+		name    string
+		zone    *hcloud.Zone
+		dnsName string
+		target  string
+		// Expected target with ALLOW_RELATIVE_CNAME_TARGETS disabled (default), every
+		// target is made absolute.
 		wantTarget string
+		// Expected target with ALLOW_RELATIVE_CNAME_TARGETS enabled, targets which do not
+		// end with a public suffix stay relative.
+		wantTargetRelativeAllowed string
 	}{
 		{
-			name:       "absolute target in same zone",
-			zone:       &hcloud.Zone{Name: "example.de"},
-			dnsName:    "www.example.de",
-			target:     "node1.example.de",
-			wantTarget: "node1.example.de.",
+			name:                      "absolute target in same zone",
+			zone:                      &hcloud.Zone{Name: "example.de"},
+			dnsName:                   "www.example.de",
+			target:                    "node1.example.de",
+			wantTarget:                "node1.example.de.",
+			wantTargetRelativeAllowed: "node1.example.de.",
 		},
 		{
-			name:       "absolute target in other zone",
-			zone:       &hcloud.Zone{Name: "example.de"},
-			dnsName:    "www.example.de",
-			target:     "node1.other.de",
-			wantTarget: "node1.other.de.",
+			name:                      "absolute target in other zone",
+			zone:                      &hcloud.Zone{Name: "example.de"},
+			dnsName:                   "www.example.de",
+			target:                    "node1.other.de",
+			wantTarget:                "node1.other.de.",
+			wantTargetRelativeAllowed: "node1.other.de.",
 		},
 		{
-			name:       "relative target in same zone",
-			zone:       &hcloud.Zone{Name: "example.de"},
-			dnsName:    "www.example.de",
-			target:     "node1",
-			wantTarget: "node1",
-		},
-		{
-			// external-dns always strips the trailing dots, but we want to make sure we
-			// handle this case if it were to change.
-			name:       "absolute target in same zone with trailing dot",
-			zone:       &hcloud.Zone{Name: "example.de"},
-			dnsName:    "www.example.de",
-			target:     "node1.example.de.",
-			wantTarget: "node1.example.de.",
+			name:                      "relative target in same zone",
+			zone:                      &hcloud.Zone{Name: "example.de"},
+			dnsName:                   "www.example.de",
+			target:                    "node1",
+			wantTarget:                "node1.",
+			wantTargetRelativeAllowed: "node1",
 		},
 		{
 			// external-dns always strips the trailing dots, but we want to make sure we
 			// handle this case if it were to change.
-			name:       "absolute target in other zone with trailing dot",
-			zone:       &hcloud.Zone{Name: "example.de"},
-			dnsName:    "www.example.de",
-			target:     "node1.other.de.",
-			wantTarget: "node1.other.de.",
+			name:                      "absolute target in same zone with trailing dot",
+			zone:                      &hcloud.Zone{Name: "example.de"},
+			dnsName:                   "www.example.de",
+			target:                    "node1.example.de.",
+			wantTarget:                "node1.example.de.",
+			wantTargetRelativeAllowed: "node1.example.de.",
+		},
+		{
+			// external-dns always strips the trailing dots, but we want to make sure we
+			// handle this case if it were to change.
+			name:                      "absolute target in other zone with trailing dot",
+			zone:                      &hcloud.Zone{Name: "example.de"},
+			dnsName:                   "www.example.de",
+			target:                    "node1.other.de.",
+			wantTarget:                "node1.other.de.",
+			wantTargetRelativeAllowed: "node1.other.de.",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			target := adjustCNAMETarget(tt.target)
-			require.Equal(t, tt.wantTarget, target)
+			t.Run("relative targets disallowed", func(t *testing.T) {
+				target := adjustCNAMETarget(tt.target, false)
+				require.Equal(t, tt.wantTarget, target)
+			})
+
+			t.Run("relative targets allowed", func(t *testing.T) {
+				target := adjustCNAMETarget(tt.target, true)
+				require.Equal(t, tt.wantTargetRelativeAllowed, target)
+			})
 		})
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -15,17 +15,20 @@ import (
 )
 
 type Provider struct {
-	client *hcloud.Client
-	logger *slog.Logger
+	client                    *hcloud.Client
+	logger                    *slog.Logger
+	allowRelativeCNAMETargets bool
 }
 
 func NewProvider(
 	client *hcloud.Client,
 	logger *slog.Logger,
+	allowRelativeCNAMETargets bool,
 ) *Provider {
 	return &Provider{
-		client: client,
-		logger: logger,
+		client:                    client,
+		logger:                    logger,
+		allowRelativeCNAMETargets: allowRelativeCNAMETargets,
 	}
 }
 
@@ -52,7 +55,7 @@ func (p *Provider) AdjustEndpoints(endpoints []*endpoint.Endpoint) ([]*endpoint.
 
 		if ep.RecordType == "CNAME" {
 			for i := range ep.Targets {
-				target := adjustCNAMETarget(ep.Targets[i])
+				target := adjustCNAMETarget(ep.Targets[i], p.allowRelativeCNAMETargets)
 				if ep.Targets[i] != target {
 					p.logger.Debug(
 						"adjusted endpoint target",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -74,7 +74,7 @@ func TestAdjustEndpoints(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, _, _, client, logger := testutil.MakeTestUtils(t)
 
-			hetznerProvider := NewProvider(client, logger)
+			hetznerProvider := NewProvider(client, logger, false)
 
 			actual, err := hetznerProvider.AdjustEndpoints(tt.incoming)
 			require.NoError(t, err)
@@ -102,7 +102,8 @@ func TestRecords(t *testing.T) {
 					{
 						DNSName: fmt.Sprintf("mydomain.%s", zoneName),
 						Targets: endpoint.NewTargets("127.0.0.1"),
-					}}
+					},
+				}
 			},
 			mocksFn: func(zoneName string) []mockutil.Request {
 				return []mockutil.Request{
@@ -127,7 +128,8 @@ func TestRecords(t *testing.T) {
 					{
 						DNSName: zoneName, // Domain apex
 						Targets: endpoint.NewTargets("127.0.0.1"),
-					}}
+					},
+				}
 			},
 			mocksFn: func(zoneName string) []mockutil.Request {
 				return []mockutil.Request{
@@ -155,7 +157,7 @@ func TestRecords(t *testing.T) {
 
 			server.Expect(tt.mocksFn(zoneName))
 
-			hetznerProvider := NewProvider(client, logger)
+			hetznerProvider := NewProvider(client, logger, false)
 
 			actual, err := hetznerProvider.Records(ctx)
 			require.NoError(t, err)
@@ -309,7 +311,7 @@ func TestApplyCreateChanges(t *testing.T) {
 			inputEndpoints := tt.inputEndpointsFn(zoneName)
 			server.Expect(tt.mocksFn(zoneName, inputEndpoints))
 
-			hetznerProvider := NewProvider(client, logger)
+			hetznerProvider := NewProvider(client, logger, false)
 
 			zones := []*hcloud.Zone{{Name: zoneName}}
 
@@ -390,7 +392,7 @@ func TestApplyDeleteChanges(t *testing.T) {
 			inputEndpoints := tt.inputEndpointsFn(zoneName)
 			server.Expect(tt.mocksFn(zoneName, inputEndpoints))
 
-			hetznerProvider := NewProvider(client, logger)
+			hetznerProvider := NewProvider(client, logger, false)
 
 			zones := []*hcloud.Zone{{Name: zoneName}}
 
@@ -545,7 +547,7 @@ func TestApplyUpdateChanges(t *testing.T) {
 			newEndpoints := tt.newEndpointsFn(zoneName)
 			server.Expect(tt.mocksFn(zoneName, oldEndpoints, newEndpoints))
 
-			hetznerProvider := NewProvider(client, logger)
+			hetznerProvider := NewProvider(client, logger, false)
 
 			zones := []*hcloud.Zone{{Name: zoneName}}
 			err := hetznerProvider.applyUpdateChanges(ctx, zones, oldEndpoints, newEndpoints)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -16,6 +17,10 @@ import (
 	"github.com/hetzner/external-dns-hetzner-webhook/internal/version"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/envutil"
+)
+
+const (
+	AllowRelativeCNAMETargets = "ALLOW_RELATIVE_CNAME_TARGETS"
 )
 
 func main() {
@@ -48,7 +53,16 @@ func main() {
 
 	hcloudClient := hcloud.NewClient(clientOpts...)
 
-	provider := provider.NewProvider(hcloudClient, logger)
+	allowRelativeCNAMETargets := false
+	if env, ok := os.LookupEnv(AllowRelativeCNAMETargets); ok {
+		allowRelativeCNAMETargets, err = strconv.ParseBool(env)
+		if err != nil {
+			logger.Error("error parsing boolean config value", "env", AllowRelativeCNAMETargets, "error", err)
+			os.Exit(1)
+		}
+	}
+
+	provider := provider.NewProvider(hcloudClient, logger, allowRelativeCNAMETargets)
 
 	metricsAddr := ":8080"
 	if addr, ok := os.LookupEnv("METRICS_ADDRESS"); ok {

--- a/tests/e2e/cluster.go
+++ b/tests/e2e/cluster.go
@@ -287,7 +287,7 @@ func SetupHCloudClient() (*hcloud.Client, error) {
 
 func StartWebhook(client *hcloud.Client) {
 	logger := slog.New(slog.DiscardHandler)
-	provider := provider.NewProvider(client, logger)
+	provider := provider.NewProvider(client, logger, false)
 	startChan := make(chan struct{})
 	go webhook.StartHTTPApi(
 		provider,

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -126,6 +126,10 @@ func TestCreateRecords(t *testing.T) {
 	}
 }
 
+// TestCreateCNAMERecords covers the default behaviour, where every CNAME target is
+// made absolute. Relative targets require ALLOW_RELATIVE_CNAME_TARGETS and are covered
+// by the unit tests in TestAdjustCNAMETarget, the webhook under test runs as a single
+// instance with the default configuration.
 func TestCreateCNAMERecords(t *testing.T) {
 	t.Parallel()
 
@@ -157,7 +161,7 @@ func TestCreateCNAMERecords(t *testing.T) {
 		{
 			name:   "relative target in the same zone",
 			target: "nginx",
-			want:   "nginx",
+			want:   "nginx.",
 		},
 	}
 


### PR DESCRIPTION
After feedback from our [first release candidate](https://github.com/hetzner/external-dns-hetzner-webhook/releases/tag/v0.3.4-rc.0) we decided to include a feature gate for discovering relative CNAME tarets via https://publicsuffix.org/.

This PR adds a new environment variable `ALLOW_RELATIVE_CNAME_TARGETS`, which allows users to enable the discovery of relative CNAME targets. It is off by default. Furthermore, there is a new guide explaining the default behavior, the feature gate, and known limitations after enabling the feature.